### PR TITLE
Chore(devcontainer): Update config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,18 +4,16 @@
     "../.docker/docker-compose.dev.yml",
     "docker-compose.yml"
   ],
-  "service": "jupyter",
+  "service": "conda-music-repo-template",
   "workspaceFolder": "/utkusarioglu-com/templates/conda-music-repo-template",
   "settings": {
     "workbench.colorCustomizations": {
-      "activityBar.background": "#002244"
+      "activityBar.background": "#FF0000",
+      "activityBar.foreground": "#000000"
     }
   },
   "extensions": [
     "ms-python.python",
     "ms-toolsai.jupyter"
-  ],
-  "features": {
-    "github-cli": "latest"
-  }
+  ]
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,12 +1,19 @@
 version: "3.9"
 services:
-  jupyter:
+  conda-music-repo-template:
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
     volumes:
-      - vscode-extensions:/root/.vscode-server/extensions
-      - vscode-extensions-insiders:/root/.vscode-server-insiders/extensions
-      - ~/.config/gh:/home/econ/.config/gh:ro
+      - type: volume
+        source: vscode-server-extensions
+        target: /home/music/.vscode-server/extensions
+      - type: volume
+        source: vscode-server-insiders-extensions
+        target: /home/music/.vscode-server-insiders/extensions
     command: /bin/sh -c "while sleep 1000; do :; done"
 
 volumes:
-  vscode-extensions:
-  vscode-extensions-insiders:
+  vscode-server-extensions:
+    name: conda-music-repo-template-vscode-server-extensions
+  vscode-server-insiders-extensions:
+    name: conda-music-repo-template-vscode-server-insiders-extensions

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -1,7 +1,9 @@
 version: "3.9"
 
 services:
-  jupyter:
-    image: utkusarioglu/conda-music-devcontainer:1.0.3
+  conda-music-repo-template:
+    image: utkusarioglu/conda-music-devcontainer:1.0.8
     volumes:
-      - ..:/utkusarioglu-com/templates/conda-music-repo-template
+      - type: bind
+        source: ..
+        target: /utkusarioglu-com/templates/conda-music-repo-template


### PR DESCRIPTION
- Fix `docker-compose` to bear the name of the template.
- Update the devcontainer color to reflect that this is a repo template.
- Remove github cli from devcontainer features. This is because this
  tool is now consumed from the devcontainer image.
- Rename volumes of volume type to be unique.
- Remove github config bind mount.
- Add `GH_TOKEN` environment variable for github token to assume host
  identity.
- Upgrade devcontainer image to version 1.0.8.
