### PR TITLE
Chore: Implement test monitor

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,7 +2,9 @@ version: "3.9"
 
 services:
   conda-music-repo-template:
-    image: utkusarioglu/conda-music-devcontainer:1.0.8
+    image: utkusarioglu/conda-music-devcontainer:1.0.10
+    environment:
+      PYTHONPATH: /utkusarioglu-com/templates/conda-music-repo-template
     volumes:
       - type: bind
         source: ..

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Test Monitor",
+      "detail": "Run tests",
+      "type": "shell",
+      "command": "scripts/test-monitor.sh",
+      "icon": {
+        "color": "terminal.ansiYellow",
+        "id": "beaker"
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated",
+        "showReuseMessage": false,
+        "clear": false,
+        "close": false
+      }
+    }
+  ]
+}

--- a/scripts/test-monitor.sh
+++ b/scripts/test-monitor.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Starting watchmedo for pytest…"
+watchmedo shell-command \
+  --patterns "*.py" \
+  --recursive \
+  --command "\
+      pytest src \
+    " \
+  .
+  

--- a/src/greeting/greeting_utils.py
+++ b/src/greeting/greeting_utils.py
@@ -1,0 +1,2 @@
+def returns_greeting():
+  return "Hello there"

--- a/src/greeting/greeting_utils_unit_test.py
+++ b/src/greeting/greeting_utils_unit_test.py
@@ -1,0 +1,6 @@
+from greeting_utils import returns_greeting
+
+def test_returns_greeting():
+  response = returns_greeting()
+  expected = "Hello there"
+  assert(expected == response)

--- a/src/main.ipynb
+++ b/src/main.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from greeting.greeting_utils import returns_greeting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello there'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "returns_greeting()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.6 ('econ')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "7c2280d020ed2aed7cdac8de3c4dba8c6872048e6115fb0655eb08d156aeaec0"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Upgrade devcontainer image version to 1.0.10. This one comes with
  watchdog, which can be used with the test monitor.
- Define `PYTHONPATH` environment variable in `docker-compose.dev.yml`.
- Add `test-monitor.sh`, which is a facade for the pytest command that
  is being run by watchmedo.
- Add a module for greeting in `src` and call it from `main.ipynb`. Then
  test it through pytest. This is meant to be a showcase for the devs
  that use this repo template.
- Add VS Code task for convenently calling test monitor.
